### PR TITLE
Fix rendering

### DIFF
--- a/glfw_user_data.hpp
+++ b/glfw_user_data.hpp
@@ -13,7 +13,7 @@ namespace bnb
     public:
         glfw_user_data(
             offscreen_effect_player_sptr oep,
-            renderer_sptr render_target,
+            render_t_sptr render_target,
             bnb::camera_sptr& camera,
             bnb::camera_base::push_frame_cb_t push_frame_cb)
             : m_oep(oep)
@@ -32,7 +32,7 @@ namespace bnb
             return m_oep.lock();
         }
 
-        renderer_sptr render_target()
+        render_t_sptr render_target()
         {
             return m_render_target.lock();
         }
@@ -49,7 +49,7 @@ namespace bnb
     private:
         std::weak_ptr<offscreen_effect_player_sptr::element_type> m_oep;
         bnb::camera_sptr& m_camera;
-        std::weak_ptr<renderer_sptr::element_type> m_render_target;
+        std::weak_ptr<render_t_sptr::element_type> m_render_target;
         bnb::camera_base::push_frame_cb_t m_push_frame_cb;
     };
 } // namespace viewer

--- a/libraries/renderer/frame_surface_handler.cpp
+++ b/libraries/renderer/frame_surface_handler.cpp
@@ -1,0 +1,125 @@
+#include "frame_surface_handler.hpp"
+
+using namespace bnb::render;
+
+// clang-format off
+const float frame_surface_handler::vertices[2][frame_surface_handler::v_size][5 * 4] =
+{{ /* verical flip 0 */
+{
+        // positions        // texture coords
+         1.0f,  1.0f, 0.0f, 1.0f, 0.0f, // top right
+         1.0f, -1.0f, 0.0f, 1.0f, 1.0f, // bottom right
+        -1.0f, -1.0f, 0.0f, 0.0f, 1.0f, // bottom left
+        -1.0f,  1.0f, 0.0f, 0.0f, 0.0f, // top left
+},
+{
+        // positions        // texture coords
+         1.0f,  1.0f, 0.0f, 0.0f, 0.0f, // top right
+         1.0f, -1.0f, 0.0f, 1.0f, 0.0f, // bottom right
+        -1.0f, -1.0f, 0.0f, 1.0f, 1.0f, // bottom left
+        -1.0f,  1.0f, 0.0f, 0.0f, 1.0f, // top left
+},
+{
+        // positions        // texture coords
+         1.0f,  1.0f, 0.0f, 0.0f, 1.0f, // top right
+         1.0f, -1.0f, 0.0f, 0.0f, 0.0f, // bottom right
+        -1.0f, -1.0f, 0.0f, 1.0f, 0.0f, // bottom left
+        -1.0f,  1.0f, 0.0f, 1.0f, 1.0f, // top left
+},
+{
+        // positions        // texture coords
+         1.0f,  1.0f, 0.0f, 1.0f, 1.0f, // top right
+         1.0f, -1.0f, 0.0f, 0.0f, 1.0f, // bottom right
+        -1.0f, -1.0f, 0.0f, 0.0f, 0.0f, // bottom left
+        -1.0f,  1.0f, 0.0f, 1.0f, 0.0f, // top left
+}
+},
+{ /* verical flip 1 */
+{
+        // positions        // texture coords
+         1.0f, -1.0f, 0.0f, 1.0f, 1.0f, // top right
+         1.0f,  1.0f, 0.0f, 1.0f, 0.0f, // bottom right
+        -1.0f,  1.0f, 0.0f, 0.0f, 0.0f, // bottom left
+        -1.0f, -1.0f, 0.0f, 0.0f, 1.0f, // top left
+},
+{
+        // positions        // texture coords
+         1.0f, -1.0f, 0.0f, 1.0f, 0.0f, // top right
+         1.0f,  1.0f, 0.0f, 0.0f, 0.0f, // bottom right
+        -1.0f,  1.0f, 0.0f, 0.0f, 1.0f, // bottom left
+        -1.0f, -1.0f, 0.0f, 1.0f, 1.0f, // top left
+},
+{
+        // positions        // texture coords
+         1.0f, -1.0f, 0.0f, 0.0f, 0.0f, // top right
+         1.0f,  1.0f, 0.0f, 0.0f, 1.0f, // bottom right
+        -1.0f,  1.0f, 0.0f, 1.0f, 1.0f, // bottom left
+        -1.0f, -1.0f, 0.0f, 1.0f, 0.0f, // top left
+},
+{
+        // positions        // texture coords
+         1.0f, -1.0f, 0.0f, 0.0f, 1.0f, // top right
+         1.0f,  1.0f, 0.0f, 1.0f, 1.0f, // bottom right
+        -1.0f,  1.0f, 0.0f, 1.0f, 0.0f, // bottom left
+        -1.0f, -1.0f, 0.0f, 0.0f, 0.0f, // top left
+}
+}};
+// clang-format on
+
+frame_surface_handler::frame_surface_handler(bnb::oep::interfaces::rotation orientation, bool is_y_flip)
+    : m_orientation(static_cast<uint32_t>(orientation))
+    , m_y_flip(static_cast<uint32_t>(is_y_flip))
+{
+    glGenVertexArrays(1, &m_vao);
+    glGenBuffers(1, &m_vbo);
+    glGenBuffers(1, &m_ebo);
+
+    glBindVertexArray(m_vao);
+
+    glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(vertices[m_y_flip][m_orientation]), vertices[m_y_flip][m_orientation], GL_STATIC_DRAW);
+
+    // clang-format off
+    unsigned int indices[] = {
+        0, 1, 3, // first triangle
+        1, 2, 3  // second triangle
+    };
+    // clang-format on
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ebo);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
+
+    // position attribute
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*) 0);
+    glEnableVertexAttribArray(0);
+    // texture coord attribute
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*) (3 * sizeof(float)));
+    glEnableVertexAttribArray(1);
+
+    glBindVertexArray(0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+}
+
+frame_surface_handler::~frame_surface_handler()
+{
+    if (m_vao != 0)
+        glDeleteVertexArrays(1, &m_vao);
+
+    if (m_vbo != 0)
+        glDeleteBuffers(1, &m_vbo);
+
+    if (m_ebo != 0)
+        glDeleteBuffers(1, &m_ebo);
+
+    m_vao = 0;
+    m_vbo = 0;
+    m_ebo = 0;
+}
+
+void frame_surface_handler::draw()
+{
+    glBindVertexArray(m_vao);
+    glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, nullptr);
+    glBindVertexArray(0);
+}

--- a/libraries/renderer/frame_surface_handler.hpp
+++ b/libraries/renderer/frame_surface_handler.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <glad/glad.h>
+#include <algorithm>
+#include <interfaces/image_format.hpp>
+
+#define BNB_GLSL_VERSION "#version 330 core \n"
+
+namespace bnb::render
+{
+    class frame_surface_handler
+    {
+    private:
+        static const auto v_size = static_cast<uint32_t>(bnb::oep::interfaces::rotation::deg270) + 1;
+
+    public:
+        /**
+         * First array determines texture orientation for vertical flip transformation
+         * Second array determines texture's orientation
+         * Third one determines the plane vertices` positions in correspondence to the texture coordinates
+         */
+        static const float vertices[2][v_size][5 * 4];
+
+        explicit frame_surface_handler(bnb::oep::interfaces::rotation orientation, bool is_y_flip);
+        virtual ~frame_surface_handler() final;
+
+        frame_surface_handler(const frame_surface_handler&) = delete;
+        frame_surface_handler(frame_surface_handler&&) = delete;
+
+        frame_surface_handler& operator=(const frame_surface_handler&) = delete;
+        frame_surface_handler& operator=(frame_surface_handler&&) = delete;
+
+        void draw();
+
+    private:
+        uint32_t m_orientation = 0;
+        uint32_t m_y_flip = 0;
+        unsigned int m_vao = 0;
+        unsigned int m_vbo = 0;
+        unsigned int m_ebo = 0;
+    };
+} // namespace bnb::render

--- a/libraries/renderer/render_thread.cpp
+++ b/libraries/renderer/render_thread.cpp
@@ -1,0 +1,49 @@
+#include "render_thread.hpp"
+
+using namespace bnb::render;
+
+render_thread::render_thread(GLFWwindow* window, int32_t width, int32_t height)
+    : m_window(window)
+    , m_thread([this, width, height]() { thread_func(width, height); })
+    , m_cancellation_flag(false)
+{
+}
+
+render_thread::~render_thread()
+{
+    m_cancellation_flag = true;
+    m_thread.join();
+}
+
+void render_thread::surface_changed(int32_t width, int32_t height)
+{
+    if (m_renderer) {
+        m_renderer->surface_change(width, height);
+    }
+}
+
+void render_thread::update_data(int texture_id)
+{
+    if (m_renderer)
+        m_renderer->update_data(texture_id);
+}
+
+void render_thread::thread_func(int32_t width, int32_t height)
+{
+    using namespace std::chrono_literals;
+
+    glfwMakeContextCurrent(m_window);
+    glfwSwapInterval(1);
+
+    m_renderer = std::make_unique<renderer>(width, height);
+
+    while (!m_cancellation_flag) {
+        if (m_renderer->draw()) {
+            glfwSwapBuffers(m_window);
+        } else {
+            std::this_thread::sleep_for(1us);
+        }
+    }
+    m_renderer.reset();
+    glfwMakeContextCurrent(nullptr);
+}

--- a/libraries/renderer/render_thread.hpp
+++ b/libraries/renderer/render_thread.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <glad/glad.h>
+#define GLFW_INCLUDE_NONE
+#include <GLFW/glfw3.h>
+
+#include <thread>
+
+#include "renderer.hpp"
+
+namespace bnb::render
+{
+    class render_thread;
+}
+
+using render_t_sptr = std::shared_ptr<bnb::render::render_thread>;
+using render_t_wptr = std::weak_ptr<bnb::render::render_thread>;
+
+namespace bnb::render
+{
+    class render_thread
+    {
+    public:
+        render_thread(GLFWwindow* window, int32_t width, int32_t height);
+
+        ~render_thread();
+
+        void surface_changed(int32_t width, int32_t height);
+        void update_data(int texture_id);
+
+    private:
+        void thread_func(int32_t width, int32_t height);
+
+        std::unique_ptr<renderer> m_renderer{nullptr};
+        GLFWwindow* m_window;
+        std::thread m_thread;
+        std::atomic<bool> m_cancellation_flag;
+    };
+} // namespace bnb::render

--- a/libraries/renderer/renderer.cpp
+++ b/libraries/renderer/renderer.cpp
@@ -1,146 +1,85 @@
 #include "renderer.hpp"
+#include <glad/glad.h>
+
+// RGBA texture
+namespace
+{
+    // NOTE: The shader below assumes that texture image is oriented head at the top, so it inverts y-axis
+    const char* vs =
+        " precision highp float; \n "
+        " layout (location = 0) in vec3 aPos; \n"
+        " layout (location = 1) in vec2 aTexCoord; \n"
+        " out vec2 TexCoord; \n"
+        " void main() \n"
+        " { \n"
+        " gl_Position = vec4(aPos.x, -aPos.y, aPos.z, 1.0); \n"
+        " TexCoord = aTexCoord; \n"
+        " } \n";
+
+    const char* fs =
+        "precision highp float;\n"
+        "in vec2 TexCoord;\n"
+        "out vec4 FragColor;\n"
+        "uniform sampler2D uTexture;\n"
+        "void main()\n"
+        "{\n"
+        "FragColor = texture(uTexture, TexCoord);\n"
+        "}\n";
+} // namespace
 
 using namespace bnb::render;
 
-/* renderer::~renderer */
-renderer::~renderer()
+renderer::renderer(int32_t width, int32_t height)
+    : m_program("RendererCamera", vs, fs)
+    , m_frame_surface(bnb::oep::interfaces::rotation::deg0, false)
 {
-    stop_auto_rendering();
+    surface_change(width, height);
 }
 
-/* renderer::surface_changed */
-void renderer::surface_changed(int32_t width, int32_t height)
+void renderer::surface_change(int32_t width, int32_t height)
 {
     m_width = width;
     m_height = height;
     m_surface_changed = true;
 }
 
-/* renderer::update_texture */
-void renderer::update_texture(GLuint texture)
+void renderer::update_data(int texture_id)
 {
-    m_texture_id = texture;
+    if (m_texture_updated && m_rendering) {
+        return;
+    }
+
+    m_texture_updated = false;
+    m_texture_id = texture_id;
     m_texture_updated = true;
 }
 
-/* renderer::start_auto_rendering */
-void renderer::start_auto_rendering(GLFWwindow* window)
+bool renderer::draw()
 {
-    auto thread_func = [this, window]() {
-        using namespace std::chrono_literals;
-        if (m_auto_rendering_is_running) {
-            throw std::runtime_error("auto rendering already is runing");
-        }
-        m_auto_rendering_is_running = true;
-        glfwMakeContextCurrent(window);
-        glfwSwapInterval(1);
-        initialize();
-
-        while (m_auto_rendering_is_running) {
-            if (m_surface_changed) {
-                glViewport(0, 0, m_width, m_height);
-                m_surface_changed = false;
-            }
-            if (m_texture_updated) {
-                draw_texture(m_texture_id);
-                m_texture_updated = false;
-                glfwSwapBuffers(window);
-            } else {
-                std::this_thread::sleep_for(1us);
-            }
-        }
-
-        shutdown();
-        glfwMakeContextCurrent(nullptr);
-    };
-
-    m_auto_rendering_thread = std::thread(thread_func);
-}
-
-/* renderer::stop_auto_rendering */
-void renderer::stop_auto_rendering()
-{
-    if (m_auto_rendering_is_running) {
-        m_auto_rendering_is_running = false;
-        m_auto_rendering_thread.join();
+    if (!m_texture_updated) {
+        return false;
     }
-}
 
-/* renderer::initialize */
-void renderer::initialize()
-{
-    // clang-format off
-    static const char* vertex_shader_program =
-        "precision highp float;\n "
-        "layout (location = 0) in vec3 aPos;\n"
-        "layout (location = 1) in vec2 aTexCoord;\n"
-        "out vec2 vTexCoord;\n"
-        "void main() {\n"
-        "  gl_Position = vec4(aPos, 1.0);\n"
-        "  vTexCoord = aTexCoord;\n"
-        "}\n";
-
-    static const char* fragment_shader_program =
-        "precision highp float;\n"
-        "in vec2 vTexCoord;\n"
-        "out vec4 FragColor;\n"
-        "uniform sampler2D uTexture;\n"
-        "void main() {\n"
-        "  FragColor = texture(uTexture, vTexCoord);\n"
-        "}\n";
-
-    static const float drawing_plane_coords[] = {
-        /* verical flip 0 rotation 0deg */
-        1.0f, 1.0f, 0.0f, 1.0f, 0.0f,  /* top right */
-        1.0f, -1.0f, 0.0f, 1.0f, 1.0f,  /* bottom right */
-        -1.0f, 1.0f, 0.0f, 0.0f, 0.0f, /* top left */
-        -1.0f, -1.0f, 0.0f, 0.0f, 1.0f, /* bottom left */
-    };
-    // clang-format on
-
-    m_program = std::make_unique<bnb::oep::program>("", vertex_shader_program, fragment_shader_program);
-
-    glGenVertexArrays(1, &m_vao);
-    glGenBuffers(1, &m_vbo);
-
-    glBindVertexArray(m_vao);
-    glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(drawing_plane_coords), drawing_plane_coords, GL_STATIC_DRAW);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)0);
-    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)(3 * sizeof(float)));
-    glEnableVertexAttribArray(0);
-    glEnableVertexAttribArray(1);
-    glBindVertexArray(0);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-}
-
-/* renderer::shutdown */
-void renderer::shutdown()
-{
-    if (m_vao != 0) {
-        glDeleteVertexArrays(1, &m_vao);
-        m_vao = 0;
+    if (m_surface_changed) {
+        glViewport(0, 0, m_width, m_height);
+        m_surface_changed = false;
     }
-    if (m_vbo != 0) {
-        glDeleteBuffers(1, &m_vbo);
-        m_vbo = 0;
-    }
-    m_program = nullptr;
-}
 
-/* renderer::draw_texture */
-void renderer::draw_texture(GLuint texture)
-{
-    m_program->use();
+    m_rendering = true;
+
+    m_texture_updated = false;
+
+    m_program.use();
 
     glActiveTexture(GLenum(GL_TEXTURE0));
-    glBindTexture(GL_TEXTURE_2D, texture);
+    glBindTexture(GL_TEXTURE_2D, m_texture_id);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
-    glBindVertexArray(m_vao);
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-    glBindVertexArray(0);
+    m_frame_surface.draw();
 
-    m_program->unuse();
+    m_program.unuse();
+    m_rendering = false;
+
+    return true;
 }

--- a/libraries/renderer/renderer.hpp
+++ b/libraries/renderer/renderer.hpp
@@ -1,59 +1,31 @@
 #pragma once
 
-#include <memory>
-#include <thread>
-
-#include <glad/glad.h>
-#define GLFW_INCLUDE_NONE
-#include <GLFW/glfw3.h>
-
 #include <opengl/program.hpp>
-
-namespace bnb::render
-{
-    class renderer;
-} /* namespace bnb::render */
-
-using renderer_sptr = std::shared_ptr<bnb::render::renderer>;
-using renderer_wptr = std::weak_ptr<bnb::render::renderer>;
+#include "frame_surface_handler.hpp"
 
 namespace bnb::render
 {
     class renderer
     {
     public:
-        renderer() = default;
-        
-        ~renderer();
+        renderer(int32_t width, int32_t height);
 
-        void surface_changed(int32_t width, int32_t height);
+        void surface_change(int32_t width, int32_t height);
 
-        void update_texture(GLuint texture);
-
-        void start_auto_rendering(GLFWwindow* window);
-
-        void stop_auto_rendering();
+        void update_data(int texture_id);
+        bool draw();
 
     private:
-        void initialize();
+        bnb::oep::program m_program;
+        frame_surface_handler m_frame_surface;
 
-        void shutdown();
+        int32_t m_width;
+        int32_t m_height;
+        int m_texture_id{0};
 
-        void draw_texture(GLuint texture);
+        std::atomic<bool> m_rendering = false;
+        std::atomic<bool> m_texture_updated = false;
 
-    private:
-        std::thread m_auto_rendering_thread;
-
-        std::unique_ptr<bnb::oep::program> m_program {nullptr};
-
-        int32_t m_width {0};
-        int32_t m_height {0};
-        GLuint m_texture_id {0};
-        GLuint m_vao {0};
-        GLuint m_vbo {0};
-
-        std::atomic_bool m_auto_rendering_is_running {false};
-        std::atomic_bool m_texture_updated {false};
-        std::atomic_bool m_surface_changed {false};
+        std::atomic<bool> m_surface_changed = false;
     };
 } // namespace bnb::render

--- a/main.cpp
+++ b/main.cpp
@@ -64,7 +64,7 @@ int main()
     // We want to share resources between context, we know that render_context is based on
     // GLFW and returned context is GLFWwindow
     window = std::make_shared<bnb::gl::glfw_window>("OEP Example", reinterpret_cast<GLFWwindow*>(rc->get_sharing_context()));
-    auto render_t = std::make_shared<bnb::render::renderer>();
+    render_t_sptr render_t = std::make_shared<bnb::render::render_thread>(window->get_window(), oep_width, oep_height);
 
     oep->load_effect(<#Place the effect name here, e.g. effects/test_BG#>);
 
@@ -83,7 +83,7 @@ int main()
                 auto render_callback = [render_t](std::optional<rendered_texture_t> texture_id) {
                     if (texture_id.has_value()) {
                         auto gl_texture = static_cast<GLuint>(reinterpret_cast<int64_t>(*texture_id));
-                        render_t->update_texture(gl_texture);
+                        render_t->update_data(gl_texture);
                     }
                 };
                 // Get texture id from shared context and render it
@@ -115,9 +115,6 @@ int main()
         }
 
         if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS) {
-            if (auto renderer = ud->render_target()) {
-                renderer->stop_auto_rendering();
-            }
             glfwSetWindowShouldClose(window, GLFW_TRUE);
         } else if (key == GLFW_KEY_P && action == GLFW_PRESS) {
             if (auto oep = ud->oep()) {
@@ -128,7 +125,7 @@ int main()
             if (auto oep = ud->oep()) {
                 // If key pressed when oep unstopped
                 if (ud->camera_ptr().get() == nullptr) {
-                    ud->camera_ptr() = bnb::create_camera_device(ud->push_frame_cb(), 0);
+                    ud->camera_ptr() = bnb::create_camera_device((ud->push_frame_cb(), 0);
                     oep->resume();
                 }
             }
@@ -156,7 +153,6 @@ int main()
             oep->surface_changed(w, h);
         }
     });
-    render_t->start_auto_rendering(window->get_window());
     window->show(oep_width, oep_height);
     window->run_main_loop();
 

--- a/render_context.hpp
+++ b/render_context.hpp
@@ -2,7 +2,7 @@
 
 #include <interfaces/render_context.hpp>
 #include "libraries/utils/glfw_window.hpp"
-#include "libraries/renderer/renderer.hpp"
+#include "libraries/renderer/render_thread.hpp"
 
 namespace bnb::oep
 {


### PR DESCRIPTION
Rendering has been broken. Releases 1.5.3 1.5.1 and 1.4.2 have been tested and resulted in black screen. 
Revert commits to 9a97c12f021d964ff099c9210b7bccad073cffc7 to temporarily fix rendering.